### PR TITLE
Support JCSDK env var to choose which SDK to use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,17 @@ language: java
 jdk:
   - oraclejdk8
 
+# uncomment the applicable lines if wanting to test all applet-supported SDKs
+# env:
+# the first one is to test the usage of a default SDK
+#  -
+#  - JCSDK=jc212
+#  - JCSDK=jc221
+#  - JCSDK=jc222
+#  - JCSDK=jc303
+#  - JCSDK=jc304
+#  - JCSDK=jc305u1
+
 script:
   - ./gradlew check --info
   - ./gradlew buildJavaCard --info

--- a/applet/build.gradle
+++ b/applet/build.gradle
@@ -43,21 +43,34 @@ test {
 }
 
 // JavaCard SDKs and libraries
-final def JC212 = libsSdk + '/jc212_kit'
-final def JC221 = libsSdk + '/jc221_kit'
-final def JC222 = libsSdk + '/jc222_kit'
-final def JC303 = libsSdk + '/jc303_kit'
-final def JC304 = libsSdk + '/jc304_kit'
-final def JC305 = libsSdk + '/jc305u1_kit'
+final def JC212 = 'jc212'
+final def JC221 = 'jc221'
+final def JC222 = 'jc222'
+final def JC303 = 'jc303'
+final def JC304 = 'jc304'
+final def JC305 = 'jc305u1'
 
-// Which JavaCard SDK to use - select
-final def JC_SELECTED = JC304
+// Which JavaCard SDK can be used
+final def JC_ENABLED = [
+    JC222, JC303, JC304, JC305
+]
+
+// Which JavaCard SDK to use by default
+def JC_SELECTED = JC222
+
+// Check if user wants to compile with a specific enabled JavaCard SDK
+final def JCSDK = System.getenv('JCSDK')
+if (JCSDK in JC_ENABLED) {
+    JC_SELECTED = JCSDK
+} else if (JCSDK) {
+    throw new InvalidUserDataException("JCSDK environment variable is set to an SDK not available for this project")
+}
 
 javacard {
 
     //noinspection GroovyAssignabilityCheck
     config {
-        jckit JC_SELECTED
+        jckit "${libsSdk}/${JC_SELECTED}_kit"
 
         // JCardSim automatically added by the javacard-gradle plugin
         addSurrogateJcardSimRepo true
@@ -69,7 +82,7 @@ javacard {
             packageName 'applet'
             version '0.1'
             aid '01:02:03:04:05:06:07:08:09'
-            output 'applet.cap'
+            output "${JC_SELECTED}_applet.cap"
 
             //noinspection GroovyAssignabilityCheck
             applet {


### PR DESCRIPTION
Support `JCSDK` env var to choose which SDK to use.
`JCSDK` env var, if present, is checked against a list of enabled JavaCard SDKs.
The names of the SDKs correspond to the folder names in the `libs-sdks` folder (without the common `_kit` component).

Default configuration starts with first supported JDK the 2.2.2 for general usage standards.