### PR TITLE
fix: JUnit test annotations for running tests with current gradle configuration

### DIFF
--- a/applet/src/test/java/tests/AppletTest.java
+++ b/applet/src/test/java/tests/AppletTest.java
@@ -1,7 +1,7 @@
 package tests;
 
 import org.junit.Assert;
-import org.testng.annotations.*;
+import org.junit.jupiter.api.*;
 
 import javax.smartcardio.CommandAPDU;
 import javax.smartcardio.ResponseAPDU;
@@ -17,19 +17,19 @@ public class AppletTest extends BaseTest {
     public AppletTest() {
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws Exception {
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() throws Exception {
     }
 
-    @BeforeMethod
+    @BeforeEach
     public void setUpMethod() throws Exception {
     }
 
-    @AfterMethod
+    @AfterEach
     public void tearDownMethod() throws Exception {
     }
 


### PR DESCRIPTION
Hi, I've found a bug and I'm sending a fix for it.

Current gradle configuration uses JUnit for tests. TestNG was used previously. However, `AppletTest.java` contains methods with annotations incorrectly for TestNG instead of JUnit. This causes that `gradlew check` does not run any tests! We can see that [failing test](https://github.com/mvondracek/javacard-gradle-template-edu/commit/78296a5a9fb37599011bdd4151eb8f19d1c738d9) is not detected in CI, because [`gradlew check` terminates *successfuly* without running any test](https://travis-ci.org/github/mvondracek/javacard-gradle-template-edu/builds/676995835).

When [I change annotations from TestNG to JUnit Jupiter](https://github.com/mvondracek/javacard-gradle-template-edu/commit/6e7a1df832935590f47990c581384dc72bc29fae) (also single commit in this PR), [CI correctly detects failed test](https://travis-ci.org/github/mvondracek/javacard-gradle-template-edu/builds/677008538).

~~~
tests.AppletTest > failingTest() FAILED
    java.lang.AssertionError: Example of a failing test.
        at org.junit.Assert.fail(Assert.java:88)
        at tests.AppletTest.failingTest(AppletTest.java:48)
~~~

Main change is that `@Test` (and other annotations too) is now imported from `org.junit.jupiter.api` instead of `org.testng.annotations`.